### PR TITLE
config update for docfx.json

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -47,12 +47,7 @@
           "images/**"
         ]
       }
-    ],
-    "overwrite": [{
-      "files": [
-          "toc.yml"
-      ]
-  }],    
+    ],    
     "output": "_site",
     "globalMetadata": {
       "_appLogoPath": ".",


### PR DESCRIPTION
remove overwrite as functionality isn't in use.
this will also remove the build process warning about duplicate toc files.
to be re-enabled once/if the overwrite feature is needed.