### PR TITLE
GitHub wf update

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,27 +22,35 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
-    - name: Setup DocFX
-      uses: crazy-max/ghaction-chocolatey@v1
-      with:
-        args: install docfx
+    - name: Update DocFX
+      run: dotnet tool update -g docfx
 
     - name: DocFX Build
       working-directory: docs
       run: docfx .\docfx.json
       continue-on-error: false
 
-    - name: Publish
-      if: github.event_name == 'push'
-      uses: peaceiris/actions-gh-pages@v3
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v4
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_site
-        force_orphan: true
+        path: 'docs/_site'
+
+    - name: Deploy to GitHub Pages
+      if: github.event_name == 'push'
+      id: deployment
+      uses: actions/deploy-pages@v4
+
+#    - name: Publish
+#      if: github.event_name == 'push'
+#      uses: peaceiris/actions-gh-pages@v3
+#      with:
+#        github_token: ${{ secrets.GITHUB_TOKEN }}
+#        publish_dir: docs/_site
+#        force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       continue-on-error: false
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v3
       with:
         path: 'docs/_site'
 


### PR DESCRIPTION
Update to the pipeline definition:

* Use newer versions of actions/gh versions of actions
* Use .net 8 (up from 6)
* Use latest DocFx version (currently 2.76), install through `dotnet` command
* Should resolve dependencies on deprecated node runners

this should resolve the build warnings spawned from current version.
Needs some testing in this repo to make sure it runs as expected/same as in other repos